### PR TITLE
sync with oficial grocerycrud, security input fixeds, datatables and php 7.3 compat

### DIFF
--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -3259,12 +3259,12 @@ class grocery_CRUD_States extends grocery_CRUD_Layout
                         if (is_array($data['search_field'])) {
                             $search_array = array();
                             foreach ($data['search_field'] as $search_key => $search_field_name) {
-                                $search_field_name = preg_replace('/[^a-zA-Z0-9_]/', '' , $search_field_name);
+                                $search_field_name = preg_replace("/[=\"'?\\\\]/", '' , $search_field_name);
                                 $search_array[$search_field_name] = isset($data['search_text'][$search_key]) ? $data['search_text'][$search_key] : '';
                             }
                             $state_info->search	= $search_array;
                         } else {
-                            $field_name = preg_replace('/[^a-zA-Z0-9_]/', '' , $data['search_field']);
+                            $field_name = preg_replace("/[=\"'?\\\\]/", '' , $data['search_field']);
                             $state_info->search	= (object)array(
                                 'field' => $field_name,
                                 'text' => $data['search_text'] );

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -2832,17 +2832,18 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 				case 'invisible':
 					unset($this->add_fields[$field_num]);
 					unset($fields[$field_num]);
-					continue;
-				break;
+				    break;
 				case 'hidden':
 					$this->add_hidden_fields[] = $field_input;
 					unset($this->add_fields[$field_num]);
 					unset($fields[$field_num]);
-					continue;
-				break;
+				    break;
+                default:
+                    $input_fields[$field->field_name] = $field_input;
+                    break;
 			}
 
-			$input_fields[$field->field_name] = $field_input;
+
 		}
 
 		return $input_fields;

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -2876,17 +2876,18 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 				case 'invisible':
 					unset($this->edit_fields[$field_num]);
 					unset($fields[$field_num]);
-					continue;
-				break;
+				    break;
 				case 'hidden':
 					$this->edit_hidden_fields[] = $field_input;
 					unset($this->edit_fields[$field_num]);
 					unset($fields[$field_num]);
-					continue;
-				break;
+				    break;
+                default:
+                    $input_fields[$field->field_name] = $field_input;
+                    break;
 			}
 
-			$input_fields[$field->field_name] = $field_input;
+
 		}
 
 		return $input_fields;

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -732,9 +732,16 @@ class grocery_CRUD_Model_Driver extends grocery_CRUD_Field_Types
 			foreach($add_fields as $add_field)
 			{
 				$field_name = $add_field->field_name;
-				if(!isset($this->validation_rules[$field_name]) && in_array( $field_name, $required_fields) )
-				{
-					$this->set_rules( $field_name, $field_types[$field_name]->display_as, 'required');
+
+                // Workaround as Codeigniter set_rules has a bug with array and doesn't work with required fields.
+                // We are basically doing the check here!
+                if (array_key_exists($field_name, $this->relation_n_n) && in_array($field_name, $required_fields)) {
+                    if (!array_key_exists($field_name, $_POST)) {
+                        // This will always throw an error!
+                        $this->set_rules($field_name, $field_types[$field_name]->display_as, 'required');
+                    }
+                } else if(!isset($this->validation_rules[$field_name]) && in_array( $field_name, $required_fields) ) {
+					$this->set_rules($field_name, $field_types[$field_name]->display_as, 'required');
 				}
 			}
 		}

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -825,10 +825,19 @@ class grocery_CRUD_Model_Driver extends grocery_CRUD_Field_Types
 			foreach($edit_fields as $edit_field)
 			{
 				$field_name = $edit_field->field_name;
-				if(!isset($this->validation_rules[$field_name]) && in_array( $field_name, $required_fields) )
-				{
-					$this->set_rules( $field_name, $field_types[$field_name]->display_as, 'required');
+
+                // Workaround as Codeigniter set_rules has a bug with array and doesn't work with required fields.
+                // We are basically doing the check here!
+				if (array_key_exists($field_name, $this->relation_n_n) && in_array($field_name, $required_fields)) {
+                    if (!array_key_exists($field_name, $_POST)) {
+                        // This will always throw an error!
+                        $this->set_rules($field_name, $field_types[$field_name]->display_as, 'required');
+                    }
+                } else if(!isset($this->validation_rules[$field_name]) && in_array( $field_name, $required_fields) ) {
+					$this->set_rules($field_name, $field_types[$field_name]->display_as, 'required');
 				}
+
+
 			}
 		}
 

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -2935,17 +2935,18 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
 			    case 'invisible':
 			    	unset($this->read_fields[$field_num]);
 			    	unset($fields[$field_num]);
-			    	continue;
 			    	break;
 			    case 'hidden':
 			    	$this->read_hidden_fields[] = $field_input;
 			    	unset($this->read_fields[$field_num]);
 			    	unset($fields[$field_num]);
-			    	continue;
 			    	break;
+                default:
+                    $input_fields[$field->field_name] = $field_input;
+                    break;
+
 			}
 
-			$input_fields[$field->field_name] = $field_input;
 		}
 
 		return $input_fields;

--- a/assets/grocery_crud/languages/polish.php
+++ b/assets/grocery_crud/languages/polish.php
@@ -1,45 +1,45 @@
 <?php  
 /* Translated by: @slav123 */
-	$lang['list_add'] 				= 'Dodaj';
+	$lang['list_add'] 			= 'Dodaj';
 	$lang['list_actions'] 			= 'Operacje';
-	$lang['list_page'] 				= 'Strony';
+	$lang['list_page'] 			= 'Strony';
 	$lang['list_paging_of'] 		= 'z';
 	$lang['list_displaying']		= 'Wyświetlanie od {start} do {end} z {results} rekordów';
 	$lang['list_filtered_from']		= '(filtrowanie spośród {total_results} dostępnych pozycji)';
 	$lang['list_show_entries']		= 'Wyświetlanie {paging} pozycji';
 	$lang['list_no_items']			= 'Brak pozycji do wyświetlenia';
-	$lang['list_zero_entries']		= 'Zero wyników';
+	$lang['list_zero_entries']		= 'Brak wyników';
 	$lang['list_search'] 			= 'Szukaj';
 	$lang['list_search_all'] 		= 'Szukaj wszystkie';
-	$lang['list_clear_filtering'] 	= 'Wyczyść filtry';
+	$lang['list_clear_filtering'] 		= 'Usuń filtry';
 	$lang['list_delete'] 			= 'Usuń';
-	$lang['list_edit'] 				= 'Edytuj';
+	$lang['list_edit'] 			= 'Edytuj';
 	$lang['list_paging_first'] 		= 'Pierwszy';
-	$lang['list_paging_previous'] 	= 'Poprzedni';
+	$lang['list_paging_previous'] 		= 'Poprzedni';
 	$lang['list_paging_next'] 		= 'Następny';
 	$lang['list_paging_last'] 		= 'Ostatni';
 	$lang['list_loading'] 			= 'Ładowanie...';
 
-	$lang['form_edit'] 				= 'Edytuj';
+	$lang['form_edit'] 			= 'Edytuj';
 	$lang['form_back_to_list'] 		= 'Wróć do listy';
-	$lang['form_update_changes'] 	= 'Zapisz zmiany';
+	$lang['form_update_changes'] 		= 'Zapisz zmiany';
 	$lang['form_cancel'] 			= 'Anuluj';
-	$lang['form_update_loading'] 	= 'Aktualizacja, proszę czekać...';
-	$lang['update_success_message'] = 'Rekord zostały pomyślnie zaktualizowany.';
-	$lang['form_go_back_to_list'] 	= 'Wróć do listy';
+	$lang['form_update_loading'] 		= 'Aktualizacja, proszę czekać...';
+	$lang['update_success_message'] 	= 'Rekord zostały pomyślnie zaktualizowany.';
+	$lang['form_go_back_to_list'] 		= 'Wróć do listy';
 
-	$lang['form_add'] 				= 'Dodaj';
-	$lang['insert_success_message'] = 'Rekord został pomyślnie zapisany.';
-	$lang['form_or']				= 'lub';
-	$lang['form_save'] 				= 'Zapisz';
-	$lang['form_insert_loading'] 	= 'Zapisywanie, proszę czekać...';
+	$lang['form_add'] 			= 'Dodaj';
+	$lang['insert_success_message'] 	= 'Rekord został pomyślnie zapisany.';
+	$lang['form_or']			= 'lub';
+	$lang['form_save'] 			= 'Zapisz';
+	$lang['form_insert_loading'] 		= 'Zapisywanie, proszę czekać...';
 
-	$lang['form_upload_a_file'] 	= 'Dodaj plik';
-	$lang['form_upload_delete'] 	= 'usuń';
+	$lang['form_upload_a_file'] 		= 'Dodaj plik';
+	$lang['form_upload_delete'] 		= 'usuń';
 	$lang['form_button_clear'] 		= 'Wyczyść';
 
-	$lang['delete_success_message'] = 'Rekord został pomyślnie usunięty z bazy danych.';
-	$lang['delete_error_message'] 	= 'Rekord nie został usunięty z bazy danych.';
+	$lang['delete_success_message']		= 'Rekord został pomyślnie usunięty z bazy danych.';
+	$lang['delete_error_message'] 		= 'Rekord nie został usunięty z bazy danych.';
 
 	/* Javascript messages */
 	$lang['alert_add_form']			= 'Dane które dodałeś mogą nie być  zapisane.\\nNa pewno chcesz wrócić do listy?';
@@ -56,46 +56,43 @@
 	$lang['form_active']			= 'aktywny';
 	
 	/* Added in version 1.2.2 */
-	$lang['form_save_and_go_back']	= 'Zapisz i wróć do listy';
-	$lang['form_update_and_go_back']= 'Zaktualizuj i wróc do listy';
+	$lang['form_save_and_go_back']		= 'Zapisz i wróć do listy';
+	$lang['form_update_and_go_back']	= 'Zaktualizuj i wróc do listy';
 
 	/* Upload functionality */
-	$lang['string_delete_file'] 	= "Usuwanie pliku";
+	$lang['string_delete_file'] 		= "Usuwanie pliku";
 	$lang['string_progress'] 		= "Postęp: ";
-	$lang['error_on_uploading'] 	= "Pojawił się błąd podczas wgrywania pliku.";
+	$lang['error_on_uploading'] 		= "Pojawił się błąd podczas wgrywania pliku.";
 	$lang['message_prompt_delete_file'] 	= "Na pewno chcesz usunąć ten plik?";
 	
-	$lang['error_max_number_of_files'] 	= "Możesz tylko wgrać jeden plik na raz.";
+	$lang['error_max_number_of_files'] 	= "Możesz wgrać tylko jeden plik na raz.";
 	$lang['error_accept_file_types'] 	= "Nie możesz wgrywać plików tego typu.";
 	$lang['error_max_file_size'] 		= "Wybrany plik przekracza maksymalny rozmiar {max_file_size} dozwolonych plików.";
 	$lang['error_min_file_size'] 		= "Nie możesz wgrywać pustego pliku.";
 
 	/* Added in version 1.3.1 */
-	$lang['list_export'] 	= "Eksportuj";
-	$lang['list_print'] 	= "Drukuj";
-	$lang['minimize_maximize'] = 'Minimalizuj/Maksymalizuj';
+	$lang['list_export'] 			= "Eksportuj";
+	$lang['list_print'] 			= "Drukuj";
+	$lang['minimize_maximize'] 		= 'Minimalizuj/Maksymalizuj';
 
 	/* Added in version 1.4 */
-	$lang['list_view'] = 'View';
+	$lang['list_view'] 			= 'Zobacz';
 
 	/* Added in version 1.5.1 */
-	$lang['ui_day'] = 'dd';
-	$lang['ui_month'] = 'mm';
-	$lang['ui_year'] = 'yyyy';
+	$lang['ui_day'] 			= 'dd';
+	$lang['ui_month'] 			= 'mm';
+	$lang['ui_year'] 			= 'yyyy';
 
 	/* Added in version 1.5.2 */
-	$lang['list_more'] = 'More';
+	$lang['list_more'] 			= 'Więcej';
 
 	/* Added in version 1.5.6 */
-	$lang['list_search_column'] = 'Search {column_name}';
+	$lang['list_search_column'] 		= 'Szukaj {column_name}';
 
 	/* Added in version 1.5.8 */
-	$lang['alert_delete_multiple'] = 'Are you sure that you want to delete those {items_amount} items?';
+	$lang['alert_delete_multiple'] 		= 'Czy na pewno chcesz usunąć te rekordy ({items_amount}) ?';
 
-	$lang['alert_delete_multiple_one'] = 'Are you sure that you want to delete this 1 item?';
-
-
+	$lang['alert_delete_multiple_one'] 	= 'Czy na pewno chcesz usunąć ten rekord?';
 
 	/* Added in version 1.6.1 */
-	$lang['list_clone'] = 'Clone';
-
+	$lang['list_clone'] 			= 'Klonuj';

--- a/assets/grocery_crud/themes/datatables/js/datatables.js
+++ b/assets/grocery_crud/themes/datatables/js/datatables.js
@@ -13,6 +13,16 @@ function supports_html5_storage()
 	}
 }
 
+function success_message(message) {
+	$('#list-report-success').html(message);
+    $('#list-report-success').slideDown();
+}
+
+function error_message(message) {
+    $('#list-report-error').html(message);
+    $('#list-report-error').slideDown();
+}
+
 var use_storage = supports_html5_storage();
 
 var aButtons = [];
@@ -210,8 +220,6 @@ function delete_row(delete_url , row_id)
 			{
 				if(data.success)
 				{
-					success_message(data.success_message);
-
 					chosen_table = datatables_get_chosen_table($('tr#row-'+row_id).closest('.groceryCrudTable'));
 
 					$('tr#row-'+row_id).addClass('row_selected');

--- a/assets/grocery_crud/themes/flexigrid/js/flexigrid.js
+++ b/assets/grocery_crud/themes/flexigrid/js/flexigrid.js
@@ -1,3 +1,13 @@
+function success_message(message) {
+    $('#list-report-success').html(message);
+    $('#list-report-success').slideDown();
+}
+
+function error_message(message) {
+    $('#list-report-error').html(message);
+    $('#list-report-error').slideDown();
+}
+
 $(function(){
 	$('.quickSearchButton').click(function(){
 		$(this).closest('.flexigrid').find('.quickSearchBox').slideToggle('normal');
@@ -170,8 +180,6 @@ $(function(){
 					if(data.success)
 					{
 						this_container.find('.ajax_refresh_and_loading').trigger('click');
-
-						success_message(data.success_message);
 					}
 					else
 					{

--- a/change_log.txt
+++ b/change_log.txt
@@ -3,6 +3,7 @@ v1.6.3
    - #470: Update Polish translation by @tikky
    - #468: Remove PHP 7.3 warnings
    - #38: Bug fix: required_fields doesn't work for relation_n_n fields
+   - #469: datatables theme - update table fails after delete
 v 1.6.2
     - #442: Searching in grid with value 0 is not working
     - #458: Updated Lithuanian language by @dgvirtual

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,6 +1,7 @@
 v1.6.3
    - #465: Translation for Spanish Uruguay by @mlopezcoria
    - #468: Remove PHP 7.3 warnings
+   - #38: required_field doesn't work for relation_n_n fields
 v 1.6.2
     - #442: Searching in grid with value 0 is not working
     - #458: Updated Lithuanian language by @dgvirtual

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,6 @@
 v1.6.3
    - #465: Translation for Spanish Uruguay by @mlopezcoria
+   - #468: Remove PHP 7.3 warnings
 v 1.6.2
     - #442: Searching in grid with value 0 is not working
     - #458: Updated Lithuanian language by @dgvirtual

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,6 @@
 v1.6.3
    - #465: Translation for Spanish Uruguay by @mlopezcoria
+   - #470: Update Polish translation by @tikky
    - #468: Remove PHP 7.3 warnings
    - #38: Bug fix: required_fields doesn't work for relation_n_n fields
 v 1.6.2

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,7 +1,7 @@
 v1.6.3
    - #465: Translation for Spanish Uruguay by @mlopezcoria
    - #468: Remove PHP 7.3 warnings
-   - #38: required_fields doesn't work for relation_n_n fields
+   - #38: Bug fix: required_fields doesn't work for relation_n_n fields
 v 1.6.2
     - #442: Searching in grid with value 0 is not working
     - #458: Updated Lithuanian language by @dgvirtual

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,7 +1,7 @@
 v1.6.3
    - #465: Translation for Spanish Uruguay by @mlopezcoria
    - #468: Remove PHP 7.3 warnings
-   - #38: required_field doesn't work for relation_n_n fields
+   - #38: required_fields doesn't work for relation_n_n fields
 v 1.6.2
     - #442: Searching in grid with value 0 is not working
     - #458: Updated Lithuanian language by @dgvirtual


### PR DESCRIPTION
* remove php 7.3 warnings
* datatables theme - update table fails after delete
* required_fields doesn't work for relation_n_n fields
* input filters chars for security